### PR TITLE
updates dateutils to version at or newer than 2.5.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,5 @@ setup(name="pyrestcli",
       version="0.6.4",
       license="MIT",
       url="https://github.com/danicarrion/pyrestcli",
-      install_requires=['requests>=2.10.0', 'python-dateutil==2.5.3', 'future==0.15.2'],
+      install_requires=['requests>=2.10.0', 'python-dateutil>=2.5.3', 'future==0.15.2'],
       packages=["pyrestcli"])


### PR DESCRIPTION
cartoframes was getting some version conflicts when installing both pandas and pyrestcli. Pandas requires `python-dateutils >= 2` while pyrestcli wants `python-dateutils==2.5.3`.