### PR TITLE
adds ratelimitexception

### DIFF
--- a/pyrestcli/auth.py
+++ b/pyrestcli/auth.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     from urlparse import urljoin
 
-from .exceptions import BadRequestException, NotFoundException, ServerErrorException, AuthErrorException
+from .exceptions import BadRequestException, NotFoundException, ServerErrorException, AuthErrorException, RateLimitException
 
 
 class BaseAuthClient(object):

--- a/pyrestcli/auth.py
+++ b/pyrestcli/auth.py
@@ -56,6 +56,8 @@ class BaseAuthClient(object):
             raise ServerErrorException(_("Internal server error"))
         elif response.status_code in (requests.codes.unauthorized, requests.codes.forbidden):
             raise AuthErrorException(_("Access denied"))
+        elif response.status_code == requests.codes.too_many_requests:
+            raise RateLimitException(_("Rate limit exceeded"))
         else:
             raise ServerErrorException(_("Unknown error occurred"))
 

--- a/pyrestcli/exceptions.py
+++ b/pyrestcli/exceptions.py
@@ -12,3 +12,8 @@ class ServerErrorException(Exception):
 
 class AuthErrorException(Exception):
     pass
+
+
+class RateLimitException(Exception):
+    """429 Too Many Requests Error"""
+    pass


### PR DESCRIPTION
If a rate limit error is encountered, it is bucketed into the 'Unknown' category. It would be useful to be able to catch this error knowing it's HTTP status code error reason. Further, since pyrestcli forms the backbone of the carto python package, and Carto now has rate limit errors (e.g., if a query over the sql api takes longer than a certain time), then a 429 error is thrown. We need to be able to reliably catch and handle the specific errors that come up.

cc @danicarrion 