### PR TITLE
improve error handling

### DIFF
--- a/pyrestcli/auth.py
+++ b/pyrestcli/auth.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     from urlparse import urljoin
 
-from .exceptions import BadRequestException, NotFoundException, ServerErrorException, AuthErrorException, RateLimitException
+from .exceptions import BaseException
 
 
 class BaseAuthClient(object):
@@ -46,20 +46,8 @@ class BaseAuthClient(object):
             if parse_json:
                 return response.json()
             return response.content
-        elif response.status_code == requests.codes.bad_request:
-            response_json = response.json()
-            raise BadRequestException(response_json.get("error", False) or response_json.get("errors",
-                                                                                             _("Bad Request: {text}").format(text=response.text)))
-        elif response.status_code == requests.codes.not_found:
-            raise NotFoundException(_("Resource not found: {url}").format(url=response.url))
-        elif response.status_code == requests.codes.internal_server_error:
-            raise ServerErrorException(_("Internal server error"))
-        elif response.status_code in (requests.codes.unauthorized, requests.codes.forbidden):
-            raise AuthErrorException(_("Access denied"))
-        elif response.status_code == requests.codes.too_many_requests:
-            raise RateLimitException(_(response.text))
         else:
-            raise ServerErrorException(_("Unknown error occurred"))
+            raise BaseException.create(response)
 
 
 class NoAuthClient(BaseAuthClient):

--- a/pyrestcli/exceptions.py
+++ b/pyrestcli/exceptions.py
@@ -1,19 +1,61 @@
-class BadRequestException(Exception):
+import sys
+
+ERRORS = {
+    400: 'BadRequestException',
+    401: 'UnauthorizedErrorException',
+    403: 'ForbiddenErrorException',
+    404: 'NotFoundException',
+    422: 'UnprocessableEntityError',
+    429: 'RateLimitException',
+    500: 'ServerErrorException'
+}
+
+
+class BaseException(Exception):
+    def __init__(self, message, status_code=None, headers=None, reason=None, url=None):
+        super(Exception, self).__init__(message)
+        self.status_code = status_code
+        self.headers = headers
+        self.reason = reason
+        self.url = url
+
+    @staticmethod
+    def create(response):
+        response_json = response.json()
+        message = response_json.get("error", response_json.get("errors", response.text))
+        headers = response.headers
+        status_code = response.status_code
+        reason = response.reason
+        url = response.url
+
+        error = ERRORS.get(status_code, 'BaseException')
+        klass = getattr(sys.modules[__name__], error)
+        raise klass(message, status_code, headers, reason, url)
+
+
+class BadRequestException(BaseException):
     pass
 
 
-class NotFoundException(Exception):
+class UnauthorizedErrorException(BaseException):
     pass
 
 
-class ServerErrorException(Exception):
+class ForbiddenErrorException(BaseException):
     pass
 
 
-class AuthErrorException(Exception):
+class NotFoundException(BaseException):
     pass
 
 
-class RateLimitException(Exception):
-    """429 Too Many Requests Error"""
+class UnprocessableEntityError(BaseException):
+    pass
+
+
+class RateLimitException(BaseException):
+    pass
+
+
+class ServerErrorException(BaseException):
     pass

--- a/pyrestcli/resources.py
+++ b/pyrestcli/resources.py
@@ -158,13 +158,13 @@ class Resource(with_metaclass(ResourceMetaclass, APIConnected)):
         :return:
         """
         response = super(Resource, self).send(url, http_method, **client_args)
+        response_data = self.client.get_response_data(response, self.Meta.parse_json)
 
         # Update Python object if we get back a full object from the API
-        if response.status_code in (requests.codes.ok, requests.codes.created):
-            try:
-                self.update_from_dict(self.client.get_response_data(response, self.Meta.parse_json))
-            except ValueError:
-                pass
+        try:
+            self.update_from_dict(response_data)
+        except ValueError:
+            pass
 
         return response if response is not None else None
 


### PR DESCRIPTION
Closes https://github.com/CartoDB/carto-python/issues/122

This PR adds more data to exceptions so that clients of the library could know what went wrong. Besides that I've done a refactor so Resource and Manager always call to `get_response_data`, so exceptions are parsed and raised if they occur.